### PR TITLE
Spec for dry

### DIFF
--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -18,19 +18,14 @@ RSpec.describe ProjectsController, type: :controller do
         # ログイン状態をシミュレートするためにsign_inヘルパー
         sign_in @user
         get :index
-        # be_successマッチャを使用し、予期していることが成功するか検証
-        expect(response).to be_success
-        # indexアクションには認証済みのユーザーでアクセスしていることになる
-      end
-
-      # 200レスポンスを返すこと
-      it "returns a 200 response" do
-        # ログイン状態をシミュレートするために sign_in ヘルパー
-        sign_in @user
-        get :index
-        # have_status_httpマッチャを使用し、どんなレスポンスを返すか検証
-        expect(response).to have_http_status "200"
-        # indexアクションには認証済みのユーザーでアクセスしていることになる
+        # 失敗の集約時に使用するaggregate_failures
+        # expectを続けて実行することができる
+        # 加えて、なぜexpectが失敗したかの原因までわかりやすくなる。
+        # テストが成功すれば、aggregate_failuresは関係ない
+        aggregate_failures do
+          expect(response).to be_success
+          expect(response).to have_http_status "200"
+        end
       end
     end
 

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -5,19 +5,14 @@ require 'rails_helper'
 # JSONの出力をテストする
 RSpec.describe TasksController, type: :controller do
 
-  before do
-    @user = FactoryBot.create(:user)
-    @project = FactoryBot.create(:project, owner: @user)
-    # @taskを生成、projectとのアソシエーションも忘れずに
-    @task = @project.tasks.create!(name: "Test task")
-  end
+  include_context "project setup"
 
   describe "#show" do
     # JSON 形式でレスポンスを返すこと
     it "responds with JSON formatted output" do
-      sign_in @user
+      sign_in user
       # ここでのリクエストにJSON形式を指定
-      get :show, format: :json, params: { project_id: @project.id, id: @task.id }
+      get :show, format: :json, params: { project_id: project.id, id: task.id }
       # application/jsonのContent-Typeでレスポンスを返すか検証
       expect(response.content_type).to eq "application/json"
     end
@@ -28,9 +23,9 @@ RSpec.describe TasksController, type: :controller do
     it "responds with JSON formatted output" do
       # taskを生成
       new_task = { name: "New test task" }
-      sign_in @user
+      sign_in user
       # showと異なる点は、new_taskを生成し、それをキーtaskのvalueがtaskのidではなく、new_taskということで、taskのパラメータも一緒に送信
-      post :create, format: :json,params: { project_id: @project.id, task: new_task }
+      post :create, format: :json, params: { project_id: project.id, task: new_task }
       # application/jsonのContent-Typeでレスポンスを返すか検証
       expect(response.content_type).to eq "application/json"
     end
@@ -38,11 +33,11 @@ RSpec.describe TasksController, type: :controller do
     # 新しいタスクをプロジェクトに追加すること
     it "adds a new task to the project" do
       new_task = { name: "New test task" }
-      sign_in @user
+      sign_in user
       expect {
         # format: :jsonとJSON形式で送ることを指定
-        post :create, format: :json, params: { project_id: @project.id, task: new_task }
-      }.to change(@project.tasks, :count).by(1)
+        post :create, format: :json, params: { project_id: project.id, task: new_task }
+      }.to change(project.tasks, :count).by(1)
       #新しくタスクが生成されたことで、taskの数に増減があるか検証
     end
 
@@ -51,8 +46,8 @@ RSpec.describe TasksController, type: :controller do
       new_task = { name: "New test task" }
       # ここではあえてログインしない
       expect {
-        post :create, format: :json, params: { project_id: @project.id, task: new_task }
-      }.to_not change(@project.tasks, :count)
+        post :create, format: :json, params: { project_id: project.id, task: new_task }
+      }.to_not change(project.tasks, :count)
       # to_notなので、期待していることは「createアクションでタスクを送信、そのタスクの数が変わっていないということ」を検証する
       expect(response).to_not be_success
       # ユーザーがログインしていないので生成できない

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe TasksController, type: :controller do
     it "responds with JSON formatted output" do
       sign_in user
       # ここでのリクエストにJSON形式を指定
-      get :show, format: :json, params: { project_id: project.id, id: task.id }
-      # application/jsonのContent-Typeでレスポンスを返すか検証
-      expect(response.content_type).to eq "application/json"
+      get :show, format: :json,
+        params: { project_id: project.id, id: task.id }
+      expect(response).to have_content_type :json
     end
   end
 
@@ -27,7 +27,7 @@ RSpec.describe TasksController, type: :controller do
       # showと異なる点は、new_taskを生成し、それをキーtaskのvalueがtaskのidではなく、new_taskということで、taskのパラメータも一緒に送信
       post :create, format: :json, params: { project_id: project.id, task: new_task }
       # application/jsonのContent-Typeでレスポンスを返すか検証
-      expect(response.content_type).to eq "application/json"
+      expect(response).to have_content_type :json
     end
 
     # 新しいタスクをプロジェクトに追加すること

--- a/spec/features/projects_spec.rb
+++ b/spec/features/projects_spec.rb
@@ -34,9 +34,15 @@ RSpec.feature "Projects", type: :feature do
       click_button "Create Project"
     }.to change(user.projects, :count).by(1)
 
-    expect(page).to have_content "Project was successfully created"
-    expect(page).to have_content "Test Project"
-    expect(page).to have_content "Owner: #{user.name}"
+    # 失敗の集約時に使用するaggregate_failures
+    # expectを続けて実行することができる
+    # 加えて、なぜexpectが失敗したかの原因までわかりやすくなる。
+    # テストが成功すれば、aggregate_failuresは関係ない
+    aggregate_failures do
+      expect(page).to have_content "Project was successfully created"
+      expect(page).to have_content "Test Project"
+      expect(page).to have_content "Owner: #{user.name}"
+    end
   end
 end
 

--- a/spec/features/projects_spec.rb
+++ b/spec/features/projects_spec.rb
@@ -11,46 +11,32 @@ require 'rails_helper'
 # MiniTest, RSpec, Cucumberといった複数のテストフレームワークから利用できる
 
 RSpec.feature "Projects", type: :feature do
-  # featureもdescribeと同様にスペックを構造化していく
 
-  # ユーザーは新しいプロジェクトを作成するというシュミレート
-  # 今回の例はhome#index、sessions#new、projects#index、projects#new、projects#createを動かしている
+  # login_support.rbのメソッドsign_in_as(user)を呼び出す
+  include LoginSupport
 
   # scenarioはitと同様にexampleの起点となる
   scenario "user creates a new project" do
     # 最初に新しいテストユーザーを作成
     user = FactoryBot.create(:user)
+    # rails_helper.rbのconfig.include Devise::Test::IntegrationHelpers, type: :featureを呼び出す
+    sign_in user
 
-    # トップページにアクセス
     visit root_path
-    # ログイン 画面からそのユーザーでログイン
-    click_link "Sign in"
-    fill_in "Email", with: user.email
-    fill_in "Password", with: user.password
-    # フォームをフィルインしたらログインボタンをクリック
-    click_button "Log in"
 
-    # アプリケーションの利用者が使うものと同じフォームを使って新しいプロジェクトを作成できるか期待
-    # この中でブラウザ上でテストしたいステップを記述、それから結果の表示が期待どおりになっていることを検証
-    expect{
+    # login_support.rbのメソッドsign_in_as(user)を呼び出す
+    # sign_in_as user
+
+    expect {
       click_link "New Project"
       fill_in "Name", with: "Test Project"
       fill_in "Description", with: "Trying out Capybara"
       click_button "Create Project"
-
-      expect(page).to have_content "Project was successfully created"
-      expect(page).to have_content "Test Project"
-      expect(page).to have_content "Owner: #{user.name}"
     }.to change(user.projects, :count).by(1)
-    # changeマッチャを使ってテスト、つまり「userがオーナーになっているプロジェクトが本当に増えたかどうか」を検証
-  end
 
-  # ゲストがプロジェクトを追加する
-  scenario "guest adds a project" do
-    visit projects_path
-    click_link "New Project"
-    # save_and_open_page はデバッグ用のメソッド
-    # save_and_open_pageによって、Railsがブラウザに返したHTMLを見ることが可能
+    expect(page).to have_content "Project was successfully created"
+    expect(page).to have_content "Test Project"
+    expect(page).to have_content "Owner: #{user.name}"
   end
 end
 

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -13,43 +13,98 @@ require 'rails_helper'
 
 RSpec.feature "Tasks", type: :feature do
 
+  let(:user) { FactoryBot.create(:user) }
+  let(:project) {
+    FactoryBot.create(:project,
+      name: "RSpec tutorial",
+      owner: user)
+    )
+  }
+
+  let!(:task) {
+    project.tasks.create!(name: "Finish RSpec tutorial")
+  }
+
   # ユーザーがタスクの状態を切り替える
-  # js: true というオプションをつけ、指定したテストにてJavaScriptが使える
-  # selenium-webdriverというgemが可能としている（CapybaraでのデフォルトのJavaScriptドライバ）
   scenario "user toggles a task", js: true do
-    user = FactoryBot.create(:user)
-    # オーナーはuserのprojectを生成
-    project = FactoryBot.create(:project, name: "RSpec tutorial", owner: user)
-    task = project.tasks.create!(name: "Finish RSpec tutorial")
+    sign_in user
+    go_to_project "RSpec tutorial"
 
-    visit root_path
-    click_link "Sign in"
-    fill_in "Email", with: user.email
-    fill_in "Password", with: user.password
-    click_button "Log in"
+    complete_task "Finish RSpec tutorial"
+    expect_complete_task "Finish RSpec tutorial"
 
-    click_link "RSpec tutorial"
-
-    # "Finish RSpec tutorial"にチェックを入れた場合
-    check "Finish RSpec tutorial"
-
-    # expect(page).to have_cssは指定したCSSに一致する要素が存在することを検証
-    expect(page).to have_css "label#task_#{task.id}.completed"
-    # reloadメソッドでtaskをリロード、それが完了するか検証
-    expect(task.reload).to be_completed
-
-    # "Finish RSpec tutorial"のチェックを外した場合
-    uncheck "Finish RSpec tutorial"
-
-    # expect(page).to_not have_cssは指定したCSSに一致する要素が存在しないことを検証
-    expect(page).to_not have_css "label#task_#{task.id}.completed"
-    expect(task.reload).to_not be_completed
+    undo_complete_task "Finish RSpec tutorial"
+    expect_incomplete_task "Finish RSpec tutorial"
   end
 
-  # 本当に遅い処理を実行する
-  scenario "runs a really slow process " do
-    using_wait_time(15) do
-      # テストを実行する
+  def go_to_project(name)
+    visit root_path
+    click_link name
+  end
+
+  def complete_task(name)
+    check name
+  end
+
+  def undo_complete_task(name)
+    uncheck name
+  end
+
+  def expect_complete_task(name)
+    aggregate_failures do
+      expect(page).to have_css "label.completed", text: name
+      expect(task.reload).to be_completed
     end
   end
+
+  def expect_incomplete_task(name)
+    aggregate_failures do
+      expect(page).to_not have_css "label.completed", text: name
+    expect(task.reload).to_not be_completed
+  end
 end
+
+
+# ----------------------------------
+# ここから下はリファクタ前のコード
+# ----------------------------------
+
+# ユーザーがタスクの状態を切り替える
+scenario "user toggles a task", js: true do
+  user = FactoryBot.create(:user)
+  # オーナーはuserのprojectを生成
+  project = FactoryBot.create(:project, name: "RSpec tutorial", owner: user)
+  task = project.tasks.create!(name: "Finish RSpec tutorial")
+
+  visit root_path
+  click_link "Sign in"
+  fill_in "Email", with: user.email
+  fill_in "Password", with: user.password
+  click_button "Log in"
+
+  click_link "RSpec tutorial"
+
+  # "Finish RSpec tutorial"にチェックを入れた場合
+  check "Finish RSpec tutorial"
+
+  # expect(page).to have_cssは指定したCSSに一致する要素が存在することを検証
+  expect(page).to have_css "label#task_#{task.id}.completed"
+  # reloadメソッドでtaskをリロード、それが完了するか検証
+  expect(task.reload).to be_completed
+
+  # "Finish RSpec tutorial"のチェックを外した場合
+  uncheck "Finish RSpec tutorial"
+
+  # expect(page).to_not have_cssは指定したCSSに一致する要素が存在しないことを検証
+  expect(page).to_not have_css "label#task_#{task.id}.completed"
+  expect(task.reload).to_not be_completed
+end
+
+# 本当に遅い処理を実行する
+scenario "runs a really slow process " do
+  using_wait_time(15) do
+    # テストを実行する
+  end
+end
+
+# js: true というオプションをつけることで、指定したテストにてJavaScriptが使える。selenium-webdriverというgemが可能としている（CapybaraでのデフォルトのJavaScriptドライバ）

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Tasks", type: :feature do
   let(:project) {
     FactoryBot.create(:project,
       name: "RSpec tutorial",
-      owner: user)
+      owner: user
     )
   }
 
@@ -60,7 +60,8 @@ RSpec.feature "Tasks", type: :feature do
   def expect_incomplete_task(name)
     aggregate_failures do
       expect(page).to_not have_css "label.completed", text: name
-    expect(task.reload).to_not be_completed
+      expect(task.reload).to_not be_completed
+    end
   end
 end
 
@@ -70,41 +71,41 @@ end
 # ----------------------------------
 
 # ユーザーがタスクの状態を切り替える
-scenario "user toggles a task", js: true do
-  user = FactoryBot.create(:user)
-  # オーナーはuserのprojectを生成
-  project = FactoryBot.create(:project, name: "RSpec tutorial", owner: user)
-  task = project.tasks.create!(name: "Finish RSpec tutorial")
-
-  visit root_path
-  click_link "Sign in"
-  fill_in "Email", with: user.email
-  fill_in "Password", with: user.password
-  click_button "Log in"
-
-  click_link "RSpec tutorial"
-
-  # "Finish RSpec tutorial"にチェックを入れた場合
-  check "Finish RSpec tutorial"
-
-  # expect(page).to have_cssは指定したCSSに一致する要素が存在することを検証
-  expect(page).to have_css "label#task_#{task.id}.completed"
-  # reloadメソッドでtaskをリロード、それが完了するか検証
-  expect(task.reload).to be_completed
-
-  # "Finish RSpec tutorial"のチェックを外した場合
-  uncheck "Finish RSpec tutorial"
-
-  # expect(page).to_not have_cssは指定したCSSに一致する要素が存在しないことを検証
-  expect(page).to_not have_css "label#task_#{task.id}.completed"
-  expect(task.reload).to_not be_completed
-end
-
-# 本当に遅い処理を実行する
-scenario "runs a really slow process " do
-  using_wait_time(15) do
-    # テストを実行する
-  end
-end
+# scenario "user toggles a task", js: true do
+#   user = FactoryBot.create(:user)
+#   # オーナーはuserのprojectを生成
+#   project = FactoryBot.create(:project, name: "RSpec tutorial", owner: user)
+#   task = project.tasks.create!(name: "Finish RSpec tutorial")
+#
+#   visit root_path
+#   click_link "Sign in"
+#   fill_in "Email", with: user.email
+#   fill_in "Password", with: user.password
+#   click_button "Log in"
+#
+#   click_link "RSpec tutorial"
+#
+#   # "Finish RSpec tutorial"にチェックを入れた場合
+#   check "Finish RSpec tutorial"
+#
+#   # expect(page).to have_cssは指定したCSSに一致する要素が存在することを検証
+#   expect(page).to have_css "label#task_#{task.id}.completed"
+#   # reloadメソッドでtaskをリロード、それが完了するか検証
+#   expect(task.reload).to be_completed
+#
+#   # "Finish RSpec tutorial"のチェックを外した場合
+#   uncheck "Finish RSpec tutorial"
+#
+#   # expect(page).to_not have_cssは指定したCSSに一致する要素が存在しないことを検証
+#   expect(page).to_not have_css "label#task_#{task.id}.completed"
+#   expect(task.reload).to_not be_completed
+# end
+#
+# # 本当に遅い処理を実行する
+# scenario "runs a really slow process " do
+#   using_wait_time(15) do
+#     # テストを実行する
+#   end
+# end
 
 # js: true というオプションをつけることで、指定したテストにてJavaScriptが使える。selenium-webdriverというgemが可能としている（CapybaraでのデフォルトのJavaScriptドライバ）

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,7 +33,7 @@ RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   # Devise のヘルパーメソッドをテスト内で使用する
   config.include Devise::Test::ControllerHelpers, type: :controller
-
+  config.include Devise::Test::IntegrationHelpers, type: :feature
 
   config.include RequestSpecHelper, type: :request
   # If you're not using ActiveRecord, or you'd prefer not to run each of your


### PR DESCRIPTION
# What I learned

テストコードをDRYにするために必要な技術をハンズオンで実習。
- letとlet! (テスト内でインスタンス変数を再利用するかわりにlet。beforeよりも)
- aggregate_failures (失敗の集約)(エクスペクテーションを集約して、複数のスペックをひとつにする)
- custom matcher (RSpecとrspec-rails が提供しているマッチャだけではなく、独自の読みやすいマッチャの作成)
- shared_context (context（共通のセットアップ）の共有)
- support modules (必要なワークフローを切り分けモジュール化)

# Other Info

beforeブロックは、describeやcontextの前に毎回呼び出される。beforeはインスタンス変数に格納する。
letは、呼ばれた時に初めてデータを読み込むという遅延読み込みをするメソッドで、必要な時に評価され、必要でなくなれば評価されなくなる。letはインスタンス変数に格納しない。

letは、最初にメソッドが呼ばれた時に評価される。(letが遅延評価)
let!は、各テストのブロック実行前に、定義したものを作成。(各itが実行される直前に評価)
